### PR TITLE
Add starter skeleton for agent sample tracking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # agentapp
 
-A new Flutter project.
+A sample Flutter project.
+
+This repository contains a starting implementation of an agent application for
+collecting and tracking samples. The app demonstrates:
+
+- A simple role-based login screen
+- A home screen with tabs for task listings, map view and profile
+- Example tasks rendered as cards
+
+The code is meant as a foundation for further development.
 
 ## Getting Started
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,38 @@
 import 'package:flutter/material.dart';
+import 'screens/login_screen.dart';
+import 'screens/home_screen.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
+  State<MyApp> createState() => _MyAppState();
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+class _MyAppState extends State<MyApp> {
+  String? _role;
 
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
+  void _handleLogin(String role) {
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _role = role;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+    return MaterialApp(
+      title: 'Agent App',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF0A2239)),
+        useMaterial3: true,
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: _role == null
+          ? LoginScreen(onLogin: _handleLogin)
+          : HomeScreen(role: _role!),
     );
   }
 }

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,0 +1,17 @@
+class Task {
+  final String id;
+  final String customerName;
+  final String address;
+  final DateTime time;
+  final String contact;
+  String status;
+
+  Task({
+    required this.id,
+    required this.customerName,
+    required this.address,
+    required this.time,
+    required this.contact,
+    this.status = 'Assigned',
+  });
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+import 'task_list_screen.dart';
+import 'map_screen.dart';
+import 'profile_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key, required this.role});
+
+  final String role;
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _selectedIndex = 0;
+
+  late final List<Task> _tasks;
+
+  @override
+  void initState() {
+    super.initState();
+    // Example tasks
+    _tasks = [
+      Task(
+        id: '1',
+        customerName: 'John Doe',
+        address: '123 Main St',
+        time: DateTime.now(),
+        contact: '555-1234',
+      ),
+      Task(
+        id: '2',
+        customerName: 'Jane Smith',
+        address: '456 Oak Ave',
+        time: DateTime.now().add(const Duration(hours: 2)),
+        contact: '555-5678',
+      ),
+    ];
+  }
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = [
+      TaskListScreen(tasks: _tasks),
+      const MapScreen(),
+      const ProfileScreen(),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Welcome, ${widget.role}')),
+      body: pages[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Tasks'),
+          BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key, required this.onLogin});
+
+  final void Function(String role) onLogin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Agent App Login')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () => onLogin('agent'),
+              child: const Text('Login as Agent'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => onLogin('manager'),
+              child: const Text('Login as Manager'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class MapScreen extends StatelessWidget {
+  const MapScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Placeholder for map integration
+    return const Center(
+      child: Text('Map view goes here'),
+    );
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Profile'),
+    );
+  }
+}

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+
+class TaskListScreen extends StatelessWidget {
+  const TaskListScreen({super.key, required this.tasks});
+
+  final List<Task> tasks;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: tasks.length,
+      itemBuilder: (context, index) {
+        final task = tasks[index];
+        return Card(
+          margin: const EdgeInsets.all(8),
+          child: ListTile(
+            title: Text(task.customerName),
+            subtitle: Text(task.address),
+            trailing: Text(task.status),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  provider: ^6.1.1
+  google_maps_flutter: ^2.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement minimal agent app with login and home screens
- add basic task model and placeholder map/profile screens
- include sample tasks displayed in a list
- document project purpose in README
- add provider and google_maps_flutter dependencies

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f5b07dd8832f96874e3a4821540e